### PR TITLE
feat: add `--dry-run` argument

### DIFF
--- a/gh-clean-branches
+++ b/gh-clean-branches
@@ -4,6 +4,19 @@
 # will not delete branches with not commited changes
 # run inside a git repo folder
 
+DRY_RUN=false
+if [ $# -gt 0 ]; then
+  case "$1" in
+    --dry-run )
+      DRY_RUN=true
+      ;;
+    * )
+      echo "Usage: gh clean-branches [--dry-run]"
+      exit 1
+      ;;
+  esac
+fi
+
 red=$'\e[1;31m'
 green=$'\e[1;32m'
 yellow=$'\e[1;33m'
@@ -57,15 +70,17 @@ else
     for branch in "${missing_upstream_branches[@]}"; do
         printf "%s\n" "   ${branch}"
     done
-
-    for branch in "${missing_upstream_branches[@]}"; do
-        printf "%s\n" "${green}Deleting branch:${end}     ${branch}"
-        git branch -d ${branch}
-        if [[ $? -eq 1 ]]; then
-          printf "%s\n" "❌  ${red}Could not delete${end} ${branch}"
-          printf "%s\n" "${tellow}Try manually:${end} git branch -D ${branch}"
-        fi
-    done
+    
+    if [[ ${DRY_RUN} == false ]]; then
+      for branch in "${missing_upstream_branches[@]}"; do
+          printf "%s\n" "${green}Deleting branch:${end}     ${branch}"
+          git branch -d ${branch}
+          if [[ $? -eq 1 ]]; then
+            printf "%s\n" "❌  ${red}Could not delete${end} ${branch}"
+            printf "%s\n" "${tellow}Try manually:${end} git branch -D ${branch}"
+          fi
+      done
+    fi
 fi
 
 printf "\n%s\n" "${green}Done${end}"


### PR DESCRIPTION
# Why
- Thanks for creating gh extension! I wanted a handy command to delete old branches.
- I'd like to add `--dry-run` feature to prevent unexpected branch deleted, since this is a destructive operation. Also `--dry-run` feature is useful to test behavior when developing this extension.

# What
- Add envvar `DRY_RUN` and set it `true` if `--dry-run` argument is provided
- If `DRY_RUN` is true, not execute `git branch -d` / `git branch -D`