### PR TITLE
Make script default branch agnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,4 +39,4 @@ gh extension install cottand/gh-clean-branches
 
 ## Acknowledgemnts
 
-Credit goes to @davidraviv for the original form
+Credit goes to @davidraviv for the original fork

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The extension uses `git branch -d` to delete the local branches, hence it will n
 
 What is does?
 - Fetch the repo.
-- Checkout main and pull changes (needed if we want to delete the current branch)
+- Checkout the default branch (whatever that is) and pull changes (needed if we want to delete the current branch)
 - Lists all local branches
 - Lists all remote branches
 - Lists branches with missing upstream to be deleted
@@ -34,5 +34,9 @@ I may remove the last two dependencies, they are not really needed (pull request
 
 ## Installation
 ```bash
-gh extension install davidraviv/gh-clean-branches
+gh extension install cottand/gh-clean-branches
 ```
+
+## Acknowledgemnts
+
+Credit goes to @davidraviv for the original form

--- a/gh-clean-branches
+++ b/gh-clean-branches
@@ -28,10 +28,12 @@ end=$'\e[0m'
 printf "%s\n" "${green}Sync branches${end}"
 git fetch -p >/dev/null 2>&1 # hide response
 
-printf "%s\n" "${green}Checking out main${end}"
-git checkout main
+DEFAULT=$(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')
 
-printf "%s\n" "${green}Pulling main${end}"
+printf "%s\n" "${green}Checking out ${DEFAULT}${end}"
+git checkout $DEFAULT
+
+printf "%s\n" "${green}Pulling ${DEFAULT}${end}"
 git pull
 if [[ $? -eq 1 ]]
   then
@@ -51,8 +53,8 @@ const args = process.argv.slice(1);
 const local_branches_str = args[0]
 const remote_branches_str = args[1]
 
-local_branches = local_branches_str.trim().split('\n').filter(b => !b.includes(' main')).map(b => b.trim())
-remote_branches = remote_branches_str.trim().split('\n').filter(b => !b.includes(' main')).map(b => b.trim())
+local_branches = local_branches_str.trim().split('\n').filter(b => !b.includes(' ${DEFAULT}')).map(b => b.trim())
+remote_branches = remote_branches_str.trim().split('\n').filter(b => !b.includes(' ${DEFAULT}')).map(b => b.trim())
 missing_upstream_branches = local_branches.filter(b => !remote_branches.includes(b))
 
 console.log(missing_upstream_branches.join(','))


### PR DESCRIPTION
`main` as a branch name was hardcoded in the script, which stopped me from using this in my workplace, where we say `master`