### PR TITLE
Back to home branch

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+## Related issue:
+<!-- Replace ### with the related issue number -->
+[Issue ###](https://github.com/davidraviv/gh-clean-branches/issues/###)
+
+## Why did you make this change
+<!-- Describe what is the purpose of this change -->
+
+## What have you done in this PR
+<!-- High-level description of the change -->
+
+## What was left to do
+<!-- Describe what is left to do and not included in this PR -->
+
+## Dependencies
+<!-- Describe any new dependencies that this PR has -->
+
+## Checklist:
+<!-- Check the relevant options and remove the ones that aren't relevant -->
+
+-   [ ] My code follows the style of this project
+-   [ ] I have performed a self-review of my own code
+-   [ ] I have have tested my code locally to prove my fix is effective or that my feature works
+-   [ ] I have made corresponding changes to the README.md

--- a/README.md
+++ b/README.md
@@ -6,17 +6,11 @@ Safely delete local branches that have no remotes and no hanging changes.
 
 The extension uses `git branch -d` to delete the local branches, hence it will not delete branches with un-pushed changes.
 
-What is does?
-- Fetch the repo.
-- Checkout the default branch (e.g `main`) and pull changes (needed if we want to delete the current branch)
-- Lists all local branches
-- Lists all remote branches
-- Lists branches with missing upstream to be deleted
-- Deletes branches with no upstream and no un-pushed changes.
+## Installation
+```bash
+gh extension install davidraviv/gh-clean-branches
+```
 
-When the extension completes, it stays on the default branch of the repo.
-
-When using the `--dry-run` flag, the last delete branches command is skipped. All the rest is always performed.
 ## Usage
 Execute it inside a git repo folder:
 ```bash
@@ -24,15 +18,21 @@ gh clean-branches [--dry-run]
 ```
 Use the `--dry-run` flag to see the list of branches to be deleted before actually deleting them.
 
+## Script flow
+- Fetches the repo
+- Checkout the default branch (e.g `main`) and pull changes (needed if we want to delete the current branch)
+- Lists all local branches
+- Lists all remote branches
+- Lists branches with missing upstream to be deleted
+- Deletes branches with no upstream and no un-pushed changes _(Skipped on `--dry-run`)_
+- Checkout the branch we started with unless it was deleted, then stays on the default branch
+
+When using the `--dry-run` flag, deleting the branches is skipped. All the rest is always performed.
 ## Dependencies
 The extension relays on:
-- gh CLI 2.0
+- gh CLI v2.0
+- git v2.22
 - zsh
 - node.js
 
 I may remove the last two dependencies, they are not really needed (pull requests are welcomed!). It helped me for fast developing it.
-
-## Installation
-```bash
-gh extension install davidraviv/gh-clean-branches
-```

--- a/gh-clean-branches
+++ b/gh-clean-branches
@@ -27,13 +27,14 @@ printf "%s\n" "${green}Sync branches${end}"
 git fetch -p >/dev/null 2>&1 # hide response
 
 upstream_name=$(git remote show)
+home_branch=$(git branch --show-current)
 default_branch=$(git remote show ${upstream_name} | awk '/HEAD branch/ {print $NF}')
 
 printf "%s\n" "${green}Checking out ${default_branch}${end}"
 git checkout $default_branch
 
 printf "%s\n" "${green}Pulling ${default_branch}${end}"
-git pull
+git pull ${upstream_name} ${default_branch}
 if [[ $? -eq 1 ]]
   then
     printf "%s\n" "${red}Failed pull, Check for uncomited changes.${end}"
@@ -41,6 +42,7 @@ if [[ $? -eq 1 ]]
 fi
 
 local_branches_str=$(git branch)
+local_branches_str=${local_branches_str/\*?/  } # trim the "*"" on the current branch
 remote_branches_str=$(git branch -r)
 remote_branches_str=${remote_branches_str//${upstream_name}\// } # trim the "origin/" from branch names
 
@@ -85,5 +87,8 @@ else
         printf "%s\n" "${green}Dry run: not deleting branches${end}"
     fi
 fi
+
+# Trying to checkout the home branch, if this branch was deleted, it will silently fail and stay on the default_branch
+git checkout $home_branch >/dev/null 2>&1 # hide response
 
 printf "\n%s\n" "${green}Done${end}"


### PR DESCRIPTION
## Related issue:
<!-- Replace ### with the related issue number -->
[Issue 6](https://github.com/davidraviv/gh-clean-branches/issues/6)

## Why did you make this change
<!-- Describe what is the purpose of this change -->
When the run completes, it stay on the same branch we started with unless it was deleted, then it completes on the default branch.
## What have you done in this PR
<!-- High-level description of the change -->
- Keep the `home_branch` before checking out to the default branch.
- When the run is completed, gracefully checkout `home_branch`, silent any errors.
- Updated README.
- Added PR template.
## What was left to do
<!-- Describe what is left to do and not included in this PR -->

## Dependencies
<!-- Describe any new dependencies that this PR has -->
- git v2.22 (used to get the current branch name)
## Checklist:
<!-- Check the relevant options and remove the ones that aren't relevant -->

-   [x] My code follows the style of this project
-   [x] I have performed a self-review of my own code
-   [x] I have have tested my code locally to prove my fix is effective or that my feature works
-   [x] I have made corresponding changes to the README.md