### PR TITLE
fix: generic shebang

### DIFF
--- a/gh-clean-branches
+++ b/gh-clean-branches
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 
 # safely delete local branches that have no remotes and no hanging changes
 # will not delete branches with not committed changes


### PR DESCRIPTION
This PR changes the shebang of the `gh-clean-branches` file for the script to be portable across distributions, specifically making it work with NixOS.