### PR TITLE
feat: add --worktrees flag to remove orphaned local worktrees

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,19 +16,21 @@ gh extension install davidraviv/gh-clean-branches
 ## Usage
 Execute it inside a git repo folder:
 ```bash
-gh clean-branches [--dry-run] [--force] [--verbose]
+gh clean-branches [--dry-run] [--force] [--verbose] [--worktrees]
 ```
 ### Options
 
-- `--dry-run` See the list of branches to be deleted before actually deleting them.
-- `--force` Uses `git branch -D` forcing a branch to be deleted regardless if upstream branches have local changes. Use carefully!
+- `--dry-run` See the list of branches and worktrees to be deleted before actually deleting them.
+- `--force` Uses `git branch -D` forcing a branch to be deleted regardless if upstream branches have local changes. Also force-removes worktrees that have uncommitted changes. Use carefully!
 - `--verbose` Print all log statements.
+- `--worktrees` Also remove local worktrees whose remote branch has been deleted, then delete their local branch. Worktrees in detached HEAD state are removed as well. Without this flag, worktree cleanup is skipped and existing behaviour is unchanged.
 
 ## Script flow
 - Fetches the repo
 - Checkout the default branch (e.g `main`) and pull changes (needed if we want to delete the current branch)
 - Lists all remote branches _(only with `--verbose` flag)_
 - Lists all local branches _(only with `--verbose` flag)_
+- _(With `--worktrees`)_ Lists orphaned worktrees (remote branch gone or detached HEAD) and removes them
 - Lists branches with missing upstream to be deleted
 - Deletes branches with no upstream and no un-pushed changes _(Skipped on `--dry-run`)_
 - Checkout the branch we started with unless it was deleted, then stays on the default branch

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ gh clean-branches [--dry-run] [--force] [--verbose] [--worktrees]
 - `--dry-run` See the list of branches and worktrees to be deleted before actually deleting them.
 - `--force` Uses `git branch -D` forcing a branch to be deleted regardless if upstream branches have local changes. Also force-removes worktrees that have uncommitted changes. Use carefully!
 - `--verbose` Print all log statements.
-- `--worktrees` Also remove local worktrees whose remote branch has been deleted, then delete their local branch. Worktrees in detached HEAD state are removed as well. Without this flag, worktree cleanup is skipped and existing behaviour is unchanged.
+- `--worktrees` Also remove local worktrees whose remote branch has been deleted, then delete their local branch. Worktrees in detached HEAD state (no branch) are removed as well. Without this flag, worktree cleanup is skipped and existing behaviour is unchanged.
 
 ## Script flow
 - Fetches the repo

--- a/gh-clean-branches
+++ b/gh-clean-branches
@@ -155,12 +155,13 @@ if [[ ${CLEAN_WORKTREES} == true ]]; then
       for wt_remove_path in "${orphaned_worktree_paths[@]}"; do
         printf "%s\n" "${green}Removing worktree:${end}   ${wt_remove_path}"
         if [[ ${FORCE_DELETE} == true ]]; then
-          git worktree remove --force "${wt_remove_path}" 2>/dev/null
+          remove_err=$(git worktree remove --force "${wt_remove_path}" 2>&1)
         else
-          git worktree remove "${wt_remove_path}" 2>/dev/null
+          remove_err=$(git worktree remove "${wt_remove_path}" 2>&1)
         fi
         if [[ $? -ne 0 ]]; then
           printf "%s\n" "❌  ${red}Could not remove${end} ${wt_remove_path}"
+          printf "%s\n" "   ${remove_err}"
           [[ ${FORCE_DELETE} != true ]] && printf "%s\n" "${yellow}Try using --force flag${end}"
         fi
       done

--- a/gh-clean-branches
+++ b/gh-clean-branches
@@ -20,8 +20,12 @@ while [[ "$#" -gt 0 ]]; do
       VERBOSE=true
       shift
       ;;
+    --worktrees)
+      CLEAN_WORKTREES=true
+      shift
+      ;;
     * )
-      printf "%s\n" "Usage: gh clean-branches [--dry-run] [--force] [--verbose]"
+      printf "%s\n" "Usage: gh clean-branches [--dry-run] [--force] [--verbose] [--worktrees]"
       exit 1
       ;;
   esac
@@ -92,6 +96,79 @@ if [[ ${FORCE_DELETE} == true ]]; then
   delete_flag='-D'
 else
   delete_flag='-d'
+fi
+
+# Worktree cleanup — runs before branch deletion so checked-out branches can be removed afterward
+if [[ ${CLEAN_WORKTREES} == true ]]; then
+  worktree_output=$(git worktree list --porcelain)
+  main_worktree=$(printf '%s\n' "$worktree_output" | awk 'NR==1 {print $2}')
+  current_dir=$(pwd -P)
+
+  orphaned_worktree_paths=()
+  orphaned_worktree_branches=()
+  wt_path=""
+  wt_branch=""
+  wt_detached=false
+
+  while IFS= read -r line; do
+    if [[ $line == worktree\ * ]]; then
+      # evaluate the previous block before starting a new one
+      if [[ -n "$wt_path" && "$wt_path" != "$main_worktree" && "$wt_path" != "$current_dir" ]]; then
+        if [[ $wt_detached == true ]] || { [[ -n "$wt_branch" ]] && (( ${missing_upstream_branches[(I)$wt_branch]} )); }; then
+          orphaned_worktree_paths+=("$wt_path")
+          orphaned_worktree_branches+=("$wt_branch")
+        fi
+      fi
+      wt_path="${line#worktree }"
+      wt_branch=""
+      wt_detached=false
+    elif [[ $line == branch\ * ]]; then
+      wt_branch="${line#branch refs/heads/}"
+    elif [[ $line == "detached" ]]; then
+      wt_detached=true
+    fi
+  done <<< "$worktree_output"
+  # evaluate the last block
+  if [[ -n "$wt_path" && "$wt_path" != "$main_worktree" && "$wt_path" != "$current_dir" ]]; then
+    if [[ $wt_detached == true ]] || { [[ -n "$wt_branch" ]] && (( ${missing_upstream_branches[(I)$wt_branch]} )); }; then
+      orphaned_worktree_paths+=("$wt_path")
+      orphaned_worktree_branches+=("$wt_branch")
+    fi
+  fi
+
+  worktrees_count=${#orphaned_worktree_paths[@]}
+
+  if [[ ${worktrees_count} -eq 0 ]]; then
+    printf "%s\n" "${green}No orphaned worktrees found${end}"
+  else
+    printf "%s\n" "${blue}Orphaned worktrees to remove:${end}"
+    for ((i=1; i<=worktrees_count; i++)); do
+      wt_label="${orphaned_worktree_paths[$i]}"
+      [[ -n "${orphaned_worktree_branches[$i]}" ]] && wt_label+=" (branch: ${orphaned_worktree_branches[$i]})"
+      printf "%s\n" "   ${wt_label}"
+    done
+
+    if [[ ${DRY_RUN} == false ]]; then
+      [[ ${FORCE_DELETE} == true ]] && printf "%s\n" "${yellow}Force delete is enabled${end}"
+
+      for wt_remove_path in "${orphaned_worktree_paths[@]}"; do
+        printf "%s\n" "${green}Removing worktree:${end}   ${wt_remove_path}"
+        if [[ ${FORCE_DELETE} == true ]]; then
+          git worktree remove --force "${wt_remove_path}" 2>/dev/null
+        else
+          git worktree remove "${wt_remove_path}" 2>/dev/null
+        fi
+        if [[ $? -ne 0 ]]; then
+          printf "%s\n" "❌  ${red}Could not remove${end} ${wt_remove_path}"
+          [[ ${FORCE_DELETE} != true ]] && printf "%s\n" "${yellow}Try using --force flag${end}"
+        fi
+      done
+
+      git worktree prune
+    else
+      printf "%s\n" "${green}Dry run: not removing worktrees${end}"
+    fi
+  fi
 fi
 
 if [[ ${branches_count} -eq 0 ]]; then

--- a/gh-clean-branches
+++ b/gh-clean-branches
@@ -83,6 +83,7 @@ setopt extended_glob
 local_branches=("${(f)local_branches_str}")                    # split string by \n to array
 local_branches=(${local_branches:#* ${default_branch}})        # filter out default_branch
 local_branches=(${local_branches// ##})                        # trim spaces
+local_branches=(${local_branches/#\+/})                        # strip "+" prefix marking worktree-checked-out branches
 
 remote_branches=("${(f)unique_remote_branches_str}")           # split string by \n to array
 remote_branches=(${remote_branches:#* ${default_branch}})      # filter out default_branch

--- a/gh-clean-branches
+++ b/gh-clean-branches
@@ -185,10 +185,14 @@ else
 
       for branch in "${missing_upstream_branches[@]}"; do
           printf "%s\n" "${green}Deleting branch:${end}     ${branch}"
-          git branch ${delete_flag} "${branch}" -q
+          delete_err=$(git branch ${delete_flag} "${branch}" 2>&1)
           if [[ $? -ne 0 ]]; then
             printf "%s\n" "❌  ${red}Could not delete${end} ${branch}"
-            printf "%s\n" "${yellow}Try using --force flag${end}"
+            if [[ "$delete_err" == *"checked out at"* ]]; then
+              printf "%s\n" "${yellow}Branch is used by a worktree — try using --worktrees flag${end}"
+            else
+              printf "%s\n" "${yellow}Try using --force flag${end}"
+            fi
           fi
       done
     else

--- a/gh-clean-branches
+++ b/gh-clean-branches
@@ -188,7 +188,7 @@ else
           delete_err=$(git branch ${delete_flag} "${branch}" 2>&1)
           if [[ $? -ne 0 ]]; then
             printf "%s\n" "❌  ${red}Could not delete${end} ${branch}"
-            if [[ "$delete_err" == *"checked out at"* ]]; then
+            if [[ "$delete_err" == *"worktree"* ]]; then
               printf "%s\n" "${yellow}Branch is used by a worktree — try using --worktrees flag${end}"
             else
               printf "%s\n" "${yellow}Try using --force flag${end}"


### PR DESCRIPTION
## Problem

When AI agents create a new git worktree + branch per task, open a PR, and exit, the local worktree directory and branch are left behind after the PR is merged and the remote branch deleted. The existing script only cleans up local *branches* — it does not touch worktrees. Worse, `git branch -d` silently fails for a branch checked out in a worktree, so those branches get stuck too.

## Solution

A new `--worktrees` flag that:

1. Parses `git worktree list --porcelain` to find worktrees whose remote branch is gone (or in detached HEAD state).
2. Removes them with `git worktree remove` (respects `--force` for dirty worktrees).
3. Runs `git worktree prune` to clean up stale admin files.
4. The existing branch deletion loop then cleans up the now-unblocked local branches.

Existing behaviour is **completely unchanged** when `--worktrees` is not passed.

## Flag interactions

| Flag | Behaviour with `--worktrees` |
|------|------------------------------|
| `--dry-run` | Lists orphaned worktrees but does not remove them |
| `--force` | Uses `git worktree remove --force` for dirty/uncommitted worktrees |

Worktree cleanup runs **before** branch deletion — this unblocks branches that were previously impossible to delete because they were checked out in a worktree.

## How to test

```bash
# Create a worktree, push its branch, simulate a merged PR
git worktree add /tmp/test-wt -b test-feature
git push origin test-feature
git push origin --delete test-feature
git fetch -p

# Dry run — lists the worktree without removing it
gh clean-branches --worktrees --dry-run

# Real run — removes the worktree and deletes the local branch
gh clean-branches --worktrees
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)